### PR TITLE
LSNN Neurons added

### DIFF
--- a/norse/neuron/README.txt
+++ b/norse/neuron/README.txt
@@ -2,5 +2,7 @@ Questions for Jens:
 Izhikevich
 LIFBox
 states i,v,z - meaning of
-what is alpha
+what is alpha ? - hyper parameter to use in surrogate gradient computation
 first input can we give a state?
+What for values should be in **kwargs for LSNN? - dt - time step to use in integration
+what for a range should we use for beta in LSNN?

--- a/norse/neuron/lsnn_neuron.json
+++ b/norse/neuron/lsnn_neuron.json
@@ -1,0 +1,106 @@
+{
+    "abbreviation": "lsnn",
+    "elementType": "neuron",
+    "id": "LSNN",
+    "label": "long short-term memory",
+    "params": [
+        {
+            "component": "valueSlider",
+            "id": "alpha",
+            "label": "alpha",
+            "max": 200,
+            "min": 1,
+            "step": 1,
+            "type": "float",
+            "value": 100
+        },
+        {
+            "component": "valueSlider",
+            "id": "beta",
+            "label": "beta",
+            "max": 10,
+            "min": 0.1,
+            "step": 0.1,
+            "type": "torch.tensor",
+            "value": 1.8
+        },
+        {
+            "component": "valueSlider",
+            "id": "dt",
+            "label": "time step to use in integration",
+            "max": 1,
+            "min": 0.001,
+            "step": 0.001,
+            "type": "float",
+            "value": 0.001
+        },
+        {
+            "component": "valueSlider",
+            "id": "tau_adapt_inv",
+            "label": "inversed time constant of the membrane",
+            "max": 1,
+            "min": 0,
+            "step": 0.0001,
+            "type": "torch.tensor",
+            "unit": "1/ms",
+            "value": 0.0012
+         },
+        {
+            "component": "valueSlider",
+            "id": "tau_mem_inv",
+            "label": "inversed time constant of the membrane",
+            "max": 400,
+            "min": 1,
+            "step": 1,
+            "type": "torch.tensor",
+            "unit": "1/ms",
+            "value": 100
+        },
+        {
+            "component": "valueSlider",
+            "id": "tau_syn_inv",
+            "label": "inversed time constant of the synapse",
+            "max": 400,
+            "min": 1,
+            "step": 1,
+            "type": "torch.tensor",
+            "unit": "1/ms",
+            "value": 200
+         },
+        {
+            "component": "valueSlider",
+            "id": "v_leak",
+            "label": "leak potential of the membrane",
+            "max": 1,
+            "min": 0,
+            "step": 0.01,
+            "type": "torch.tensor",
+            "unit": "mV",
+            "value": 0
+         },
+        {
+            "component": "valueSlider",
+            "id": "v_reset",
+            "label": "reset potential of the membrane",
+            "max": 1,
+            "min": 0,
+            "step": 0.01,
+            "type": "torch.tensor",
+            "unit": "mV",
+            "value": 0
+        },
+        {
+            "component": "valueSlider",
+            "id": "v_th",
+            "label": "spike threshold",
+            "max": 1,
+            "min": 0,
+            "step": 0.01,
+            "type": "torch.tensor",
+            "unit": "mV",
+            "value": 1
+        }
+    ],
+    "states": ["b","i", "v", "z"]
+  }
+  

--- a/norse/neuron/lsnn_recurrent_neuron.json
+++ b/norse/neuron/lsnn_recurrent_neuron.json
@@ -1,0 +1,125 @@
+{
+    "abbreviation": "lsnn",
+    "elementType": "neuron",
+    "id": "LSNNRecurrent",
+    "label": "long short-term memory recurrent",
+    "params": [
+        {
+            "component": "valueSlider",
+            "id": "alpha",
+            "label": "alpha",
+            "max": 200,
+            "min": 1,
+            "step": 1,
+            "type": "float",
+            "value": 100
+        },
+        {
+            "component": "valueSlider",
+            "id": "beta",
+            "label": "beta",
+            "max": 10,
+            "min": 0.1,
+            "step": 0.1,
+            "type": "torch.tensor",
+            "value": 1.8
+        },
+        {
+            "component": "valueSlider",
+            "id": "dt",
+            "label": "time step to use in integration",
+            "max": 1,
+            "min": 0.001,
+            "step": 0.001,
+            "type": "float",
+            "value": 0.001
+        },
+        {
+            "component": "valueSlider",
+            "id": "hidden_size",
+            "label": "number of hidden neurons",
+            "max": 400,
+            "min": 1,
+            "step": 1,
+            "type": "int",
+            "value": 200
+        },
+        {
+            "component": "valueSlider",
+            "id": "input_size",
+            "label": "number of input neurons",
+            "max": 400,
+            "min": 1,
+            "step": 1,
+            "type": "int",
+            "value": 200
+        },
+        {
+            "component": "valueSlider",
+            "id": "tau_adapt_inv",
+            "label": "inversed time constant of the membrane",
+            "max": 1,
+            "min": 0,
+            "step": 0.0001,
+            "type": "torch.tensor",
+            "unit": "1/ms",
+            "value": 0.0012
+        },
+        {
+            "component": "valueSlider",
+            "id": "tau_mem_inv",
+            "label": "inversed time constant of the membrane",
+            "max": 400,
+            "min": 1,
+            "step": 1,
+            "type": "torch.tensor",
+            "unit": "1/ms",
+            "value": 100
+        },
+        {
+            "component": "valueSlider",
+            "id": "tau_syn_inv",
+            "label": "inversed time constant of the synapse",
+            "max": 400,
+            "min": 1,
+            "step": 1,
+            "type": "torch.tensor",
+            "unit": "1/ms",
+            "value": 200
+        },
+        {
+            "component": "valueSlider",
+            "id": "v_leak",
+            "label": "leak potential of the membrane",
+            "max": 1,
+            "min": 0,
+            "step": 0.01,
+            "type": "torch.tensor",
+            "unit": "mV",
+            "value": 0
+        },
+        {
+            "component": "valueSlider",
+            "id": "v_reset",
+            "label": "reset potential of the membrane",
+            "max": 1,
+            "min": 0,
+            "step": 0.01,
+            "type": "torch.tensor",
+            "unit": "mV",
+            "value": 0
+        },
+        {
+            "component": "valueSlider",
+            "id": "v_th",
+            "label": "spike threshold",
+            "max": 1,
+            "min": 0,
+            "step": 0.01,
+            "type": "torch.tensor",
+            "unit": "mV",
+            "value": 1
+        }
+    ],
+    "states": ["b","i", "v", "z"]
+  }


### PR DESCRIPTION
The LSNN Neuron and the LSNN recurrent neuron are added. 
They have a beta value as torch.tensor and a dt value as a float. 
beta is the adaption constant and dt is the time step to use in the integration.
Also at this neurons there are a new state "b". The dt value must me given as a parameter in **kwargs.